### PR TITLE
[POST] users: Possibility to override the message of UserAlready

### DIFF
--- a/kisee/views.py
+++ b/kisee/views.py
@@ -147,7 +147,8 @@ async def post_users(request: web.Request) -> web.Response:
             data["username"], data["password"], data["email"]
         )
     except UserAlreadyExist as err:
-        raise web.HTTPConflict(reason="User already exist") from err
+        msg = str(err) or "User already exist"
+        raise web.HTTPConflict(reason=msg) from err
     except ProviderError as err:
         raise web.HTTPBadRequest(reason=str(err)) from err
 


### PR DESCRIPTION
It would be interesting to be able to override the error message when a user already exists.

This would make it possible, for example, to specify to the user that the problem concerns his email address or his login.